### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ This is the website for BetterDay, a mental health/well being/mood inproving app
 
 
 
+[![Run on Repl.it](https://repl.it/badge/github/HackerPro026/BetterDay-Website)](https://repl.it/github/HackerPro026/BetterDay-Website)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@ConnorYoushaei/BetterDay-Website).